### PR TITLE
Publish workflow

### DIFF
--- a/.github/workflows/cd_publish.yml
+++ b/.github/workflows/cd_publish.yml
@@ -22,12 +22,11 @@ jobs:
       install_extras: '[dev]'
       package_dirs: s7
       build_libs: flit
-      build_cmd: 'flit build'
-      # Make this 'true' when the secret PYPI_TOKEN has been setup.
-      publish_on_pypi: false
+      build_cmd: flit build
+      publish_on_pypi: true
 
       # Documentation
       update_docs: false
     secrets:
       PyPI_token: ${{ secrets.PYPI_TOKEN }}
-      PAT: ${{ secrets.PAT }}
+      PAT: ${{ secrets.TEAM40_PAT }}

--- a/.github/workflows/cd_publish.yml
+++ b/.github/workflows/cd_publish.yml
@@ -1,0 +1,33 @@
+name: CD - Publish
+
+on:
+  release:
+    types:
+    - published
+
+jobs:
+  publish:
+    name: External
+    uses: SINTEF/ci-cd/.github/workflows/cd_release.yml@v2.5.1
+    if: github.repository == 'SINTEF/soft7' && startsWith(github.ref, 'refs/tags/v')
+    with:
+      # General
+      git_username: TEAM 4.0
+      git_email: Team4.0@SINTEF.no
+      release_branch: main
+
+      # PyPI
+      python_package: true
+      python_version_build: '3.9'
+      install_extras: '[dev]'
+      package_dirs: s7
+      build_libs: flit
+      build_cmd: 'flit build'
+      # Make this 'true' when the secret PYPI_TOKEN has been setup.
+      publish_on_pypi: false
+
+      # Documentation
+      update_docs: false
+    secrets:
+      PyPI_token: ${{ secrets.PYPI_TOKEN }}
+      PAT: ${{ secrets.PAT }}

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -7,72 +7,32 @@ on:
       - 'main'
 
 jobs:
+  basics:
+    name: External
+    uses: SINTEF/ci-cd/.github/workflows/ci_tests.yml@v2.5.1
+    with:
+      # General
+      install_extras: '[dev]'
 
-  pre-commit:
-    runs-on: ubuntu-latest
+      # pre-commit
+      run_pre-commit: true
+      python_version_pre-commit: '3.9'
+      skip_pre-commit_hooks: pylint
 
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+      # pylint & safety
+      python_version_pylint_safety: '3.9'
 
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v3
-      with:
-        python-version: "3.9"
+      run_pylint: true
+      pylint_targets: s7
+      pylint_options: --rcfile=pyproject.toml --extension-pkg-whitelist='pydantic'
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -U setuptools wheel flit
-        pip install .[dev]
+      run_safety: true
 
-    - name: Test with pre-commit
-      run: SKIP=pylint pre-commit run --all-files
+      # Build Python package
+      run_build_package: true
+      python_version_package: '3.9'
+      build_libs: flit
+      build_cmd: flit build
 
-  pylint-safety:
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 2
-
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v3
-      with:
-        python-version: "3.9"
-
-    - name: Install dependencies
-      run: |
-        python -m pip install -U pip
-        pip install -U setuptools wheel flit
-        pip install -e .[dev]
-        pip install safety
-
-    - name: Run pylint
-      run: pylint --rcfile=pyproject.toml --extension-pkg-whitelist='pydantic' -- s7
-
-    - name: Run safety
-      run: pip freeze | safety check --stdin
-
-  build-package:
-    name: Build distribution package
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
-
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v3
-      with:
-        python-version: "3.9"
-
-    - name: Install dependencies
-      run: |
-        python -m pip install -U pip
-        pip install -U setuptools wheel flit
-
-    - name: Check building distribution
-      run: flit build
+      # Documentation
+      run_build_docs: false

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -24,7 +24,7 @@ jobs:
 
       run_pylint: true
       pylint_targets: s7
-      pylint_options: --rcfile=pyproject.toml --extension-pkg-whitelist='pydantic'
+      pylint_options: "--rcfile=pyproject.toml --extension-pkg-whitelist='pydantic'"
 
       run_safety: true
 

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -24,7 +24,10 @@ jobs:
 
       run_pylint: true
       pylint_targets: s7
-      pylint_options: "--rcfile=pyproject.toml --extension-pkg-whitelist='pydantic'"
+      pylint_options: |
+        --rcfile=pyproject.toml
+        --extension-pkg-whitelist='pydantic'
+        --recursive=yes
 
       run_safety: true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ name = "soft7-pkg-quaat"
 authors = [
     {name = "Thomas Fjæstad Hagelien", email = "thomas.f.hagelien@sintef.no"},
     {name = "Casper Welzel Andersen", email = "casper.w.andersen@sintef.no"},
+    {name = "Treesa Rose Joseph", email = "treesa.joseph@sintef.no"},
 ]
 description = "SOFT7 semantic interoperability framework."
 readme = "README.md"
@@ -47,7 +48,7 @@ Home = "https://github.com/SINTEF/soft7"
 Documentation = "https://SINTEF.github.io/soft7"
 Source = "https://github.com/SINTEF/soft7"
 "Issue Tracker" = "https://github.com/SINTEF/soft7/issues"
-# Changelog = "https://github.com/SINTEF/soft7/blob/main/CHANGELOG.md"
+Changelog = "https://github.com/SINTEF/soft7/blob/main/CHANGELOG.md"
 Package = "https://pypi.org/project/soft7-pkg-quaat"
 
 [tool.flit.module]
@@ -55,7 +56,7 @@ name = "s7"
 
 # Dev tool configurations
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.9"
 ignore_missing_imports = true
 scripts_are_modules = true
 warn_unused_configs = true
@@ -64,7 +65,7 @@ allow_redefinition = true
 plugins = ["pydantic.mypy"]
 
 [tool.pylint.messages_control]
-max-line-length = 90
+max-line-length = 88
 disable = [
     "duplicate-code",
     "no-name-in-module",
@@ -79,7 +80,7 @@ max-args = 10
 max-branches = 15
 
 # [tool.pytest.ini_options]
-# minversion = "6.0"
+# minversion = "7.4"
 # addopts = "-rs --cov=s7 --cov-report=term --durations=10"
 # filterwarnings = [
 #     "ignore:.*imp module.*:DeprecationWarning",


### PR DESCRIPTION
Also, use [SINTEF/ci-cd](https://SINTEF.github.io/ci-cd) for the workflows.

Add @Treesarj as co-author.

~Note, the workflow is currently _not_ set to actually publish to PyPI ([soft7-pkg-quaat](https://pypi.org/project/soft7-pkg-quaat/)) because a repository secret has not yet been setup with rights to publishing that PyPI project.~

A new package has been established on PyPI ([soft7](https://pypi.org/project/soft7/)). The appropriate secrets have been setup to make the publish workflow work - and also publish new releases to the new PyPI project.

Closes #3 