### PR TITLE
Add dependabot and pre-commit.ci configurations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+updates:
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "CasperWA"
+    labels:
+      - "CI/CD"
+      - "skip-changelog"
+      - "priority/low"
+    target-branch: "develop"  # Temporary, use "main" when ready
+    groups:
+      actions:
+        patterns: ["*"]
+
+  # Python
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:52"
+      timezone: "Europe/Oslo"
+    reviewers:
+      - "CasperWA"
+    labels:
+      - "CI/CD"
+      - "skip-changelog"
+      - "priority/low"
+    target-branch: "develop"  # Temporary, use "main" when ready
+    groups:
+      dependencies:
+        dependency-type: "production"

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -15,8 +15,7 @@ jobs:
       install_extras: '[dev]'
 
       # pre-commit
-      run_pre-commit: true
-      python_version_pre-commit: '3.9'
+      run_pre-commit: false  # Uses pre-commit.ci (see config file .pre-commit-config.yaml)
 
       # pylint & safety
       python_version_pylint_safety: '3.9'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,17 @@
-# To install the git pre-commit hook run:
-#   pre-commit install
-# To update the pre-commit hooks run:
-#   pre-commit autoupdate
+# pre-commit.ci
+ci:
+  autofix_commit_msg: |
+      [pre-commit.ci] auto fixes from pre-commit hooks
+
+      For more information, see https://pre-commit.ci
+  autofix_prs: true
+  autoupdate_branch: 'develop'  # Use 'main' when ready
+  autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
+  autoupdate_schedule: 'weekly'
+  skip: []
+  submodules: false
+
+# hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0


### PR DESCRIPTION
Dependabot will generate grouped PRs updating the GH Actions and callable worflows, as well as the Python dependencies.

pre-commit.ci will run on PRs, "fixing" them if necessary and otherwise simply checking PRs uphold the hooks. Furthermore, it will generate PRs to update the hook versions when necessary.