### PR TITLE
Fix documentation workflow

### DIFF
--- a/.github/workflows/cd_docs.yml
+++ b/.github/workflows/cd_docs.yml
@@ -1,4 +1,4 @@
-name: CD - Documentation
+name: CI/CD - Documentation
 
 on:
   # Run for every push to the active development branch (currently 'develop')
@@ -12,6 +12,11 @@ on:
     types:
       - published
 
+  # Run for every pull request (check we can build)
+  pull_request:
+    branches:
+      - 'develop'
+
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -20,12 +25,6 @@ permissions:
   contents: read
   pages: write  # to deploy to Pages
   id-token: write  # to verify the deployment originates from an appropriate source
-
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
 
 jobs:
   build:
@@ -51,7 +50,9 @@ jobs:
           pip install -e .[docs]
 
       - name: Build documentation
-        run: sphinx-build docs public -W
+        run: |
+          mkdir -p docs/_static
+          sphinx-build docs public -W
 
       - name: Upload artifacts
         uses: actions/upload-pages-artifact@v3
@@ -62,6 +63,14 @@ jobs:
     runs-on: ubuntu-latest
 
     needs: build
+
+    # Allow only one concurrent deployment, skipping runs queued between the run
+    # in-progress and latest queued.
+    # However, do NOT cancel in-progress runs as we want to allow these production
+    # deployments to complete.
+    concurrency:
+      group: "pages"
+      cancel-in-progress: false
 
     environment:
       name: github-pages

--- a/.github/workflows/cd_docs.yml
+++ b/.github/workflows/cd_docs.yml
@@ -12,7 +12,7 @@ on:
     types:
       - published
 
-  # Run for every pull request (check we can build)
+  # Run for every pull request (check we can build, but do not build)
   pull_request:
     branches:
       - 'develop'
@@ -61,6 +61,8 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
+
+    if: github.event_name != 'pull_request'
 
     needs: build
 


### PR DESCRIPTION
Fixes #34 

First, it updates the workflow to run for all PRs against `develop` and moves the concurrency run condition to the deployment job only.

Secondly, we try to fix the issue at hand, namely that the documentation does not build properly.