### PR TITLE
Use PyPI's Trusted Publisher feature

### DIFF
--- a/.github/workflows/cd_publish.yml
+++ b/.github/workflows/cd_publish.yml
@@ -6,9 +6,9 @@ on:
     - published
 
 jobs:
-  publish:
+  build:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/cd_release.yml@v2.7.4
+    uses: SINTEF/ci-cd/.github/workflows/cd_release.yml@v2.8.0
     if: github.repository == 'SINTEF/soft7' && startsWith(github.ref, 'refs/tags/v')
     with:
       # General
@@ -23,10 +23,30 @@ jobs:
       package_dirs: s7
       build_libs: flit
       build_cmd: flit build
-      publish_on_pypi: true
+      publish_on_pypi: false
+      upload_distribution: true
 
       # Documentation
       update_docs: false
+
     secrets:
-      PyPI_token: ${{ secrets.PYPI_TOKEN }}
-      PAT: ${{ secrets.TEAM40_PAT }}
+      PAT: ${{ secrets.RELEASE_PAT }}
+
+  publish:
+    name: Publish on PyPI
+    needs: build
+    runs-on: ubuntu-latest
+
+    environment: release
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download built distritbution
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - name: Publish on PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   basics:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/ci_tests.yml@v2.7.4
+    uses: SINTEF/ci-cd/.github/workflows/ci_tests.yml@v2.8.0
     with:
       # General
       install_extras: '[dev]'


### PR DESCRIPTION
Closes #42 

Update to use [ci-cd](https://github.com/SINTEF/ci-cd) v2.8.
~As of writing, this version is still not published - but when it is, it will support [PyPI's Trusted Publisher](https://docs.pypi.org/trusted-publishers/) feature in the manner it has been implemented here.~

Note, this feature has already been setup on the `soft7` project on PyPI, expecting the `cd_publish.yml` workflow as well as the `release` environment.

Furthermore, the `TEAM40_PAT` secret has been replaced with the `RELEASE_PAT` secret.