### PR TITLE
Ensure 'skip-changelog' label is added for [bot] PRs

### DIFF
--- a/.github/workflows/ci_bot_pr_changes.yml
+++ b/.github/workflows/ci_bot_pr_changes.yml
@@ -1,0 +1,26 @@
+name: CI - Update [bot] PR
+
+on:
+  pull_request:
+    types: [opened, reopened]
+    branches:
+      - 'main'
+
+jobs:
+  add_skip-changelog_label:
+    name: Add 'skip-changelog' label
+    runs-on: ubuntu-latest
+
+    if: contains(github.actor, '[bot]')
+
+    steps:
+    - name: Add 'skip-changelog' label
+      uses: actions/github-script@v5
+      with:
+        script: |
+          github.rest.issues.addLabels({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+            labels: ['skip-changelog']
+          })


### PR DESCRIPTION
Closes #41.

If the actor of a PR contains `[bot]` in its name, the `skip-changelog` label will be added.

I cannot test this as is, the only way to test will be to wait until a bot opens a PR (specifically the `pre-commit-ci[bot]`) and see if the label is added. The label will already be automatically added to all `dependabot[bot]` PRs through its configuration file.