### PR TITLE
Ensure CI jobs are run for push-protected action branches

### DIFF
--- a/.github/workflows/cd_docs.yml
+++ b/.github/workflows/cd_docs.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'push-action/**'  # For the CasperWA/push-protected action
 
   # Run for every new release
   release:
@@ -61,7 +62,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
 
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && ( ! startsWith(github.ref_name, 'push-action/') )
 
     needs: build
 

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'push-action/**'  # For the CasperWA/push-protected action
 
 jobs:
   basics:


### PR DESCRIPTION
Fixes #57 

See [this documentation](https://github.com/CasperWA/push-protected?tab=readme-ov-file#update-your-workflow) to understand why these changes are necessary.