### PR TITLE
Remove upper level version dependency for `oteapi-core`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dynamic = ["version"]
 
 dependencies = [
     "httpx~=0.27.0",
-    "oteapi-core>=0.7.0.dev2,<1",
+    "oteapi-core>=0.7.0.dev2",
     "otelib~=0.5.0.dev0",
     "pyyaml~=6.0",
     "typing-extensions~=4.12; python_version < '3.12'",

--- a/tests/factories/test_datasource_factory.py
+++ b/tests/factories/test_datasource_factory.py
@@ -553,7 +553,7 @@ Attributes:
                 "x-soft7-unit": "Å",
             },
             "soft7___dimensions": {
-                "allOf": [{"$ref": "#/$defs/MolecularSpeciesDataSourceDimensions"}],
+                "$ref": "#/$defs/MolecularSpeciesDataSourceDimensions",
                 "default": {"N": 5},
             },
             "soft7___identity": {


### PR DESCRIPTION
Fixes #61 by fixing the expected OpenAPI (JSON) schema in the relevant test.

Fixes SemanticMatter/DataSpaces-Services#25 by removing the upper limit for the `oteapi-core` dependency.