### PR TITLE
Drop safety in favor of pip-audit

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -19,9 +19,8 @@ jobs:
       run_pre-commit: false  # Uses pre-commit.ci (see config file .pre-commit-config.yaml)
 
       # pylint & safety
-      python_version_pylint_safety: '3.10'
       run_pylint: false
-      run_safety: true
+      run_safety: false
 
       # Build Python package
       run_build_package: true
@@ -31,6 +30,27 @@ jobs:
 
       # Documentation
       run_build_docs: false
+
+  pip-audit:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+
+    - name: Install dependencies
+      run: |
+        python -m pip install -U pip
+        pip install -U setuptools wheel
+        pip install -e .[dev]
+
+    - name: Run pip-audit
+      uses: pypa/gh-action-pip-audit@v1.1.0
 
   pytest:
     name: pytest


### PR DESCRIPTION
## AI Summary

This pull request updates the CI workflow configuration in `.github/workflows/ci_tests.yml` by modifying security checks and adding a new job for dependency auditing. The most important changes involve disabling `safety` checks and introducing `pip-audit` as a replacement.

### Security checks updates:
* Disabled the `safety` check by setting `run_safety` to `false`. (`[.github/workflows/ci_tests.ymlL22-R23](diffhunk://#diff-bf607a21ebbd18b3f436cc9fac6937d9c8839c33ae022cb29c2bddd873f470ebL22-R23)`)
* Added a new `pip-audit` job to perform dependency vulnerability auditing. This job includes steps to set up Python 3.10, install dependencies, and run the `pip-audit` GitHub Action. (`[.github/workflows/ci_tests.ymlR34-R54](diffhunk://#diff-bf607a21ebbd18b3f436cc9fac6937d9c8839c33ae022cb29c2bddd873f470ebR34-R54)`)