### PR TITLE
Update HTTPX -> HTTPX2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ requires-python = "~=3.10"
 dynamic = ["version"]
 
 dependencies = [
-    "httpx>=0.28.1,<1",
+    "httpx2>=2.3,<3",
     "oteapi-core~=1.0",
     "otelib~=1.0",
     "pyyaml~=6.0",
@@ -50,9 +50,9 @@ graph = [
     "sparqlwrapper~=2.0",
 ]
 testing = [
+    "httpx2-pytest~=1.0",
     "pytest~=9.0",
     "pytest-cov~=7.0",
-    "pytest-httpx~=0.36.0",
     "requests-mock~=1.12",
     "soft7[graph]",
 ]

--- a/s7/pydantic_models/_utils.py
+++ b/s7/pydantic_models/_utils.py
@@ -149,7 +149,8 @@ def try_load_from_url(
             response = client.get(
                 str(source),
                 headers={"Accept": "application/yaml, application/json"},
-            ).raise_for_status()
+            )
+            response.raise_for_status()
         except (httpx2.HTTPStatusError, httpx2.HTTPError) as error:
             raise exception_cls(exception_msg) from error
 

--- a/s7/pydantic_models/_utils.py
+++ b/s7/pydantic_models/_utils.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, overload
 
-import httpx
+import httpx2
 import yaml
 from pydantic import AnyUrl, BaseModel, ValidationError
 
@@ -144,13 +144,13 @@ def try_load_from_url(
             "assert_dict_exception_msg should be a string when assert_dict is True."
         )
 
-    with httpx.Client(follow_redirects=True, timeout=10) as client:
+    with httpx2.Client(follow_redirects=True, timeout=10) as client:
         try:
             response = client.get(
                 str(source),
                 headers={"Accept": "application/yaml, application/json"},
             ).raise_for_status()
-        except (httpx.HTTPStatusError, httpx.HTTPError) as error:
+        except (httpx2.HTTPStatusError, httpx2.HTTPError) as error:
             raise exception_cls(exception_msg) from error
 
     return try_load_from_json_yaml(

--- a/tests/factories/test_datasource_factory.py
+++ b/tests/factories/test_datasource_factory.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from pathlib import Path
     from typing import Any, Literal
 
-    from pytest_httpx import HTTPXMock
+    from pytest_httpx2 import HTTPXMock
     from requests_mock import Mocker
 
 

--- a/tests/oteapi_plugin/test_soft7_function.py
+++ b/tests/oteapi_plugin/test_soft7_function.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from typing import Any
 
     from pydantic import AnyHttpUrl
-    from pytest_httpx import HTTPXMock
+    from pytest_httpx2 import HTTPXMock
 
     from s7.pydantic_models.soft7_entity import SOFT7Entity
     from s7.pydantic_models.soft7_instance import SOFT7EntityInstance

--- a/tests/pydantic_models/test_datasource.py
+++ b/tests/pydantic_models/test_datasource.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from pathlib import Path
     from typing import Any, Literal
 
-    from pytest_httpx import HTTPXMock
+    from pytest_httpx2 import HTTPXMock
 
     from s7.pydantic_models.datasource import GetDataConfigDict
     from s7.pydantic_models.oteapi import (
@@ -511,7 +511,7 @@ def test_parse_input_configs_http_error(
     """Ensure a proper error message occurs if an HTTP error occurs."""
     import re
 
-    from httpx import HTTPError
+    from httpx2 import HTTPError
     from pydantic import AnyHttpUrl
 
     from s7.exceptions import ConfigsNotFound

--- a/tests/pydantic_models/test_soft7_entity.py
+++ b/tests/pydantic_models/test_soft7_entity.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from pathlib import Path
     from typing import Any, Literal
 
-    from pytest_httpx import HTTPXMock
+    from pytest_httpx2 import HTTPXMock
 
 
 def test_entity_shapes_and_dimensions(
@@ -228,7 +228,7 @@ def test_parse_input_entity_http_error(httpx_mock: HTTPXMock) -> None:
     """Ensure a proper error message occurs if an HTTP error occurs."""
     import re
 
-    from httpx import HTTPError
+    from httpx2 import HTTPError
 
     from s7.exceptions import EntityNotFound
     from s7.pydantic_models.soft7_entity import parse_input_entity


### PR DESCRIPTION
Also, use httpx2-pytest over pytest-httpx.

Closes #184 

## AI Summary

This pull request upgrades the project from `httpx` to `httpx2` and updates all related dependencies and imports throughout the codebase and tests. The changes ensure compatibility with the new major version and its ecosystem, replacing all usages of the old libraries with their `httpx2` equivalents.

Dependency and import upgrades:

* Upgraded the main HTTP client dependency from `httpx` to `httpx2` in `pyproject.toml` and updated all code imports and usage from `httpx` to `httpx2`, including exception handling and client instantiation in `s7/pydantic_models/_utils.py`. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L32-R32) [[2]](diffhunk://#diff-94efd3130473efab40128f025aa6f7ab0e5b22ed1c6133107032dc8358b38d36L8-R8) [[3]](diffhunk://#diff-94efd3130473efab40128f025aa6f7ab0e5b22ed1c6133107032dc8358b38d36L147-R153)
* Updated test dependencies by removing `pytest-httpx` and adding `httpx2-pytest` in `pyproject.toml`, and replaced all imports and usages of `pytest_httpx` and `httpx.HTTPError` with `pytest_httpx2` and `httpx2.HTTPError` in test files. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R53-L55) [[2]](diffhunk://#diff-655864b381dbda8a5b63d594ab079cadbdb85215e4bef0e102f102c2d4b830acL13-R13) [[3]](diffhunk://#diff-73326072999c6e01d654b27e89ab9e3291071653dee942d09782e2e0e6aa7744L14-R14) [[4]](diffhunk://#diff-48b7fd1da2b6df91e31f6529903ab357a90e70c352c80babb9bd9aa029c92e3cL13-R13) [[5]](diffhunk://#diff-48b7fd1da2b6df91e31f6529903ab357a90e70c352c80babb9bd9aa029c92e3cL514-R514) [[6]](diffhunk://#diff-d654625f5413d660c02f6301a0b77dae95a4eedd3f078712c37c4adfc6fc4962L13-R13) [[7]](diffhunk://#diff-d654625f5413d660c02f6301a0b77dae95a4eedd3f078712c37c4adfc6fc4962L231-R231)